### PR TITLE
Hide horizontal scrollbar on sell page on desktop

### DIFF
--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -67,7 +67,7 @@ const IndexPage: NextPage = () => {
               Portfolio
             </Text>
             <Tabs.Root defaultValue="items">
-              <Flex css={{ overflowX: 'scroll' }}>
+              <Flex css={{ overflowX: 'scroll', '@sm': { overflowX: 'auto' } }}>
                 <TabsList
                   style={{
                     whiteSpace: 'nowrap',


### PR DESCRIPTION
- This only appears if user's settings have scrollbars set to always show