### PR TITLE
Display supply on token card for 1155s, move order quantity next to price

### DIFF
--- a/components/collections/TokenCard.tsx
+++ b/components/collections/TokenCard.tsx
@@ -32,7 +32,6 @@ type TokenCardProps = {
     e: SyntheticEvent<HTMLAudioElement | HTMLVideoElement, Event>
   ) => void
   tokenCount?: string
-  orderQuantity?: number
 }
 
 export default ({
@@ -42,7 +41,6 @@ export default ({
   addToCartEnabled = true,
   mutate,
   onMediaPlayed,
-  orderQuantity,
   tokenCount,
 }: TokenCardProps) => {
   const { addToast } = useContext(ToastContext)
@@ -52,6 +50,8 @@ export default ({
   const { routePrefix, proxyApi } = useMarketplaceChain()
   const tokenIsInCart = token && token?.isInCart
   const isOwner = token?.token?.owner?.toLowerCase() !== address?.toLowerCase()
+
+  const is1155 = token?.token?.kind === 'erc1155'
 
   return (
     <Box
@@ -99,7 +99,8 @@ export default ({
           </Text>
         </Flex>
       )}
-      {orderQuantity && orderQuantity > 1 && (
+
+      {is1155 && token?.token?.supply && (
         <Flex
           justify="center"
           align="center"
@@ -123,7 +124,7 @@ export default ({
             }}
             ellipsify
           >
-            x{orderQuantity}
+            x{formatNumber(token?.token?.supply, 0, true)}
           </Text>
         </Flex>
       )}
@@ -223,57 +224,68 @@ export default ({
                 </Tooltip>
               )}
             </Flex>
-            <Box
-              css={{
-                px: '$1',
-                py: 2,
-                background: '$gray5',
-                borderRadius: 8,
-                minWidth: 'max-content',
-              }}
-            >
-              {rarityEnabled &&
-                token?.token?.kind !== 'erc1155' &&
-                token?.token?.rarityRank && (
-                  <Flex align="center" css={{ gap: 5 }}>
-                    <img
-                      style={{ width: 13, height: 13 }}
-                      src="/icons/rarity-icon.svg"
-                    />
-                    <Text style="subtitle3" as="p">
-                      {formatNumber(token?.token?.rarityRank)}
-                    </Text>
-                  </Flex>
-                )}
-            </Box>
+            {rarityEnabled && !is1155 && token?.token?.rarityRank && (
+              <Box
+                css={{
+                  px: '$1',
+                  py: 2,
+                  background: '$gray5',
+                  borderRadius: 8,
+                  minWidth: 'max-content',
+                }}
+              >
+                <Flex align="center" css={{ gap: 5 }}>
+                  <img
+                    style={{ width: 13, height: 13 }}
+                    src="/icons/rarity-icon.svg"
+                  />
+                  <Text style="subtitle3" as="p">
+                    {formatNumber(token?.token?.rarityRank)}
+                  </Text>
+                </Flex>
+              </Box>
+            )}
           </Flex>
 
-          <Flex align="center" css={{ gap: '$2' }}>
-            <Box
-              css={{
-                flex: 1,
-                minWidth: 0,
-                width: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {token?.market?.floorAsk?.price && (
-                <FormatCryptoCurrency
-                  logoHeight={18}
-                  amount={token?.market?.floorAsk?.price?.amount?.decimal}
-                  address={token?.market?.floorAsk?.price?.currency?.contract}
-                  textStyle="h6"
-                  css={{
-                    textOverflow: 'ellipsis',
-                    minWidth: 0,
-                    with: '100%',
-                    overflow: 'hidden',
-                  }}
-                  maximumFractionDigits={4}
-                />
-              )}
-            </Box>
+          <Flex align="center" justify="between" css={{ gap: '$2' }}>
+            <Flex align="center" css={{ gap: '$2' }}>
+              <Box
+                css={{
+                  flex: 1,
+                  minWidth: 0,
+                  width: '100%',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {token?.market?.floorAsk?.price && (
+                  <FormatCryptoCurrency
+                    logoHeight={18}
+                    amount={token?.market?.floorAsk?.price?.amount?.decimal}
+                    address={token?.market?.floorAsk?.price?.currency?.contract}
+                    textStyle="h6"
+                    css={{
+                      textOverflow: 'ellipsis',
+                      minWidth: 0,
+                      with: '100%',
+                      overflow: 'hidden',
+                    }}
+                    maximumFractionDigits={4}
+                  />
+                )}
+              </Box>
+
+              {is1155 && token?.market?.floorAsk?.quantityRemaining ? (
+                <Text style="subtitle2" ellipsify>
+                  x
+                  {formatNumber(
+                    token?.market?.floorAsk?.quantityRemaining,
+                    0,
+                    true
+                  )}
+                </Text>
+              ) : null}
+            </Flex>
 
             <>
               {token?.market?.floorAsk?.source?.name && (

--- a/components/common/ActivityTable.tsx
+++ b/components/common/ActivityTable.tsx
@@ -32,6 +32,7 @@ import {
 import LoadingSpinner from './LoadingSpinner'
 import Img from 'components/primitives/Img'
 import optimizeImage from 'utils/optimizeImage'
+import { formatNumber } from 'utils/numbers'
 
 type CollectionActivityResponse = ReturnType<typeof useCollectionActivity>
 type CollectionActivity = CollectionActivityResponse['data'][0]
@@ -423,7 +424,7 @@ const ActivityTableRow: FC<ActivityTableRowProps> = ({ activity }) => {
             <Text style="subtitle3" color="subtle">
               Quantity
             </Text>
-            <Text style="subtitle3">{activity.amount}</Text>
+            <Text style="subtitle3">{formatNumber(activity.amount)}</Text>
           </Flex>
         ) : (
           <span>-</span>

--- a/components/common/TokenFilters.tsx
+++ b/components/common/TokenFilters.tsx
@@ -14,6 +14,7 @@ import { OpenSeaVerified } from './OpenSeaVerified'
 import { PercentChange } from 'components/primitives/PercentChange'
 import LoadMoreCollections from 'components/common/LoadMoreCollections'
 import optimizeImage from 'utils/optimizeImage'
+import { formatNumber } from 'utils/numbers'
 
 type Collections = ReturnType<typeof useUserCollections>['data']
 
@@ -126,7 +127,7 @@ export const TokenFilters: FC<Props> = ({
                     />
                   </Flex>
                   <Text style="subtitle3" css={{ color: '$gray10' }}>
-                    Owned: {collection?.ownership?.tokenCount}
+                    Owned: {formatNumber(collection?.ownership?.tokenCount)}
                   </Text>
                 </Flex>
                 <Flex

--- a/components/portfolio/PortfolioTokenCard.tsx
+++ b/components/portfolio/PortfolioTokenCard.tsx
@@ -166,35 +166,7 @@ export default ({
             }}
             ellipsify
           >
-            x{tokenCount}
-          </Text>
-        </Flex>
-      )}
-      {orderQuantity && orderQuantity > 1 && (
-        <Flex
-          justify="center"
-          align="center"
-          css={{
-            borderRadius: 8,
-            px: '$2',
-            py: '$1',
-            mr: '$2',
-            position: 'absolute',
-            left: '$2',
-            top: '$2',
-            zIndex: 1,
-            maxWidth: '50%',
-            backgroundColor: 'rgba(	38, 41, 43, 0.3)',
-            backdropFilter: 'blur(2px)',
-          }}
-        >
-          <Text
-            css={{
-              color: '$whiteA12',
-            }}
-            ellipsify
-          >
-            x{orderQuantity}
+            x{formatNumber(tokenCount, 0, true)}
           </Text>
         </Flex>
       )}

--- a/components/portfolio/TokenTable.tsx
+++ b/components/portfolio/TokenTable.tsx
@@ -58,7 +58,7 @@ import { ToastContext } from 'context/ToastContextProvider'
 import fetcher from 'utils/fetcher'
 import { DATE_REGEX, timeTill } from 'utils/till'
 import { spin } from 'components/common/LoadingSpinner'
-import { formatDollar } from 'utils/numbers'
+import { formatDollar, formatNumber } from 'utils/numbers'
 import { OpenSeaVerified } from 'components/common/OpenSeaVerified'
 import { ItemView } from './ViewToggle'
 import PortfolioTokenCard from './PortfolioTokenCard'
@@ -696,7 +696,7 @@ const TokenTableRow: FC<TokenTableRowProps> = ({
                           style="subtitle3"
                           css={{ px: '$2', fontSize: 10 }}
                         >
-                          x{token?.ownership?.tokenCount}
+                          x{formatNumber(token?.ownership?.tokenCount, 0, true)}
                         </Text>
                       </Flex>
                     )}

--- a/components/token/ListingsTable.tsx
+++ b/components/token/ListingsTable.tsx
@@ -21,7 +21,7 @@ import Link from 'next/link'
 import { FC, useContext, useEffect, useRef, useState } from 'react'
 import { MutatorCallback } from 'swr'
 import { useIntersectionObserver } from 'usehooks-ts'
-import { formatDollar } from 'utils/numbers'
+import { formatDollar, formatNumber } from 'utils/numbers'
 import { OnlyUserOrdersToggle } from './OnlyUserOrdersToggle'
 import { zeroAddress } from 'viem'
 
@@ -211,7 +211,7 @@ const ListingTableRow: FC<ListingTableRowProps> = ({
               }}
             >
               <Text style="subtitle2" color="subtle">
-                x{listing.quantityRemaining}
+                x{formatNumber(listing.quantityRemaining, 0, true)}
               </Text>
             </Flex>
           ) : null}

--- a/pages/collection/[chain]/[contract].tsx
+++ b/pages/collection/[chain]/[contract].tsx
@@ -464,9 +464,6 @@ const CollectionPage: NextPage<Props> = ({ id, ssr }) => {
                           <TokenCard
                             key={i}
                             token={token}
-                            orderQuantity={
-                              token?.market?.floorAsk?.quantityRemaining
-                            }
                             address={address as Address}
                             mutate={mutate}
                             rarityEnabled={rarityEnabledCollection}

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -12,13 +12,18 @@ function formatDollar(price?: number | null) {
 
 function formatNumber(
   amount: number | null | undefined | string,
-  maximumFractionDigits: number = 2
+  maximumFractionDigits: number = 2,
+  compact?: boolean
 ) {
   const { format } = new Intl.NumberFormat('en-US', {
     maximumFractionDigits: maximumFractionDigits,
+    notation: compact ? 'compact' : 'standard',
   })
   if (!amount) {
     return '-'
+  }
+  if (Number(amount) >= 1000000000) {
+    return '>1B'
   }
   return format(+amount)
 }


### PR DESCRIPTION
- Also updated the `formatNumber` util to support `compact` notation and return '>1B' for numbers larger than one billion